### PR TITLE
IP制限（拒否リスト）とログイン履歴とE2Eテストを追加

### DIFF
--- a/codeception/_support/AcceptanceTester.php
+++ b/codeception/_support/AcceptanceTester.php
@@ -66,7 +66,7 @@ class AcceptanceTester extends \Codeception\Actor
         $isLogin = $I->grabTextFrom('header.c-headerBar div.c-headerBar__container a.c-headerBar__userMenu span');
         if ($isLogin == '管理者 様') {
             $I->click('header.c-headerBar div.c-headerBar__container a.c-headerBar__userMenu');
-            $I->click('#page_admin_homepage div.popover .popover-body a:last-child');
+            $I->click('body div.popover .popover-body a:last-child');
             $config = Fixtures::get('config');
             $I->amOnPage('/'.$config['eccube_admin_route'].'/logout');
             $I->see('ログイン', '#form1 > button');

--- a/codeception/_support/Page/Admin/LoginHistoryPage.php
+++ b/codeception/_support/Page/Admin/LoginHistoryPage.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of EC-CUBE
+ *
+ * Copyright(c) EC-CUBE CO.,LTD. All Rights Reserved.
+ *
+ * http://www.ec-cube.co.jp/
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Page\Admin;
+
+class LoginHistoryPage extends AbstractAdminPageStyleGuide
+{
+    public static $URL = '/setting/system/login_history';
+
+    public static $検索条件 = ['id' => 'admin_search_login_history_multi'];
+    public static $検索ボタン = '#search_form .c-outsideBlock__contents button';
+    public static $詳細検索ボタン = '//*[@id="search_form"]/div[1]/div[1]/div/div/div[2]/a/span';
+    public static $検索結果_メッセージ = '//*[@id="search_form"]/div[2]/span';
+
+    public function __construct(\AcceptanceTester $I)
+    {
+        parent::__construct($I);
+    }
+
+    public static function go(\AcceptanceTester $I)
+    {
+        $page = new self($I);
+
+        return $page->goPage(self::$URL, 'ログイン履歴システム設定');
+    }
+
+    /**
+     * 指定したログインID/IPアドレスで検索する。
+     *
+     * @param string $multi ログインID/IPアドレス
+     *
+     * @return $this
+     */
+    public function 検索($multi = '')
+    {
+        $this->tester->fillField(self::$検索条件, $multi);
+        $this->tester->click(self::$検索ボタン);
+        $this->tester->see('ログイン履歴システム設定', '.c-pageTitle');
+
+        return $this;
+    }
+
+    public function 詳細検索_ステータス($value)
+    {
+        $this->tester->click(self::$詳細検索ボタン);
+        $this->tester->wait(1);
+        $this->tester->checkOption(['id' => 'admin_search_login_history_Status_'.$value]);
+        $this->tester->click(self::$検索ボタン);
+        $this->tester->see('ログイン履歴システム設定', '.c-pageTitle');
+
+        return $this;
+    }
+}

--- a/codeception/acceptance/EA08SysteminfoCest.php
+++ b/codeception/acceptance/EA08SysteminfoCest.php
@@ -13,6 +13,7 @@
 
 use Codeception\Util\Fixtures;
 use Page\Admin\AuthorityManagePage;
+use Page\Admin\LoginHistoryPage;
 
 /**
  * @group admin
@@ -308,6 +309,30 @@ class EA08SysteminfoCest
         $I->click('#page_admin_setting_system_security form div.c-contentsArea__cols > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button');
     }
 
+    /**
+     * GitHub Actions は IPv6で実行されており、アクセス拒否のテストはできない
+     */
+    public function systeminfo_セキュリティ管理IP制限_拒否リスト(\AcceptanceTester $I)
+    {
+        $I->wantTo('EA0804-UC01-T05 セキュリティ管理 - IP制限（拒否リスト）');
+
+        $findPlugins = Fixtures::get('findPlugins');
+        $Plugins = $findPlugins();
+        if (is_array($Plugins) && count($Plugins) > 0) {
+            $I->getScenario()->skip('プラグインのアンインストールが必要なため、テストをスキップします');
+        }
+
+        // 表示
+        $config = Fixtures::get('config');
+        $I->amOnPage('/'.$config['eccube_admin_route'].'/setting/system/security');
+        $I->see('セキュリティ管理システム設定', '#page_admin_setting_system_security .c-pageTitle__titles');
+
+        $I->fillField(['id' => 'admin_security_admin_deny_hosts'], '1.1.1.1');
+        $I->click('#page_admin_setting_system_security form div.c-contentsArea__cols > div.c-conversionArea > div > div > div:nth-child(2) > div > div > button');
+
+        $I->see('保存しました', AuthorityManagePage::$完了メッセージ);
+    }
+
     public function systeminfo_権限管理追加(\AcceptanceTester $I)
     {
         $I->wantTo('EA0805-UC01-T01 権限管理 - 追加');
@@ -377,12 +402,56 @@ class EA08SysteminfoCest
         $I->see('無回答', '#customer_form #admin_customer_sex');
     }
 
+    public function systeminfo_ログイン履歴検索(\AcceptanceTester $I)
+    {
+        $I->wantTo('EA0807-UC01-T01 ログイン履歴 - 検索');
+
+        LoginHistoryPage::go($I)->検索('admin');
+
+        // １項目目をチェック
+        $I->see('admin', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody/tr[1]/td[2]');
+        $I->see('成功', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody/tr[1]/td[5]/span');
+
+        LoginHistoryPage::go($I)->検索('admin-failure');
+
+        $I->see('検索結果：0件が該当しました', LoginHistoryPage::$検索結果_メッセージ);
+
+        $I->logoutAsAdmin();
+
+        // ログインに失敗する
+        $I->submitForm('#form1', [
+            'login_id' => 'admin-failure',
+            'password' => 'password',
+        ]);
+
+        $I->loginAsAdmin();
+
+        LoginHistoryPage::go($I)->検索('admin-failure');
+
+        // １項目目をチェック
+        $I->see('admin-failure', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody/tr[1]/td[2]');
+        $I->see('失敗', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody/tr[1]/td[5]/span');
+
+
+        // ステータスで詳細検索
+
+        LoginHistoryPage::go($I)->検索();
+
+        $I->see('失敗', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody');
+        $I->see('成功', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody');
+
+        LoginHistoryPage::go($I)->詳細検索_ステータス('0');
+
+        $I->see('失敗', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody');
+        $I->dontSee('成功', '//*[@id="search_form"]/div[4]/div/div/div[2]/div/table/tbody');
+    }
+
     /**
      * ATTENTION 後続のテストが失敗するため、最後に実行する必要がある
      */
-    public function systeminfo_セキュリティ管理IP制限(\AcceptanceTester $I)
+    public function systeminfo_セキュリティ管理IP制限_許可リスト(\AcceptanceTester $I)
     {
-        $I->wantTo('EA0804-UC01-T03 セキュリティ管理 - IP制限');
+        $I->wantTo('EA0804-UC01-T03 セキュリティ管理 - IP制限（許可リスト）');
 
         $findPlugins = Fixtures::get('findPlugins');
         $Plugins = $findPlugins();


### PR DESCRIPTION
## 概要(Overview・Refs Issue)
<!-- PullRequestの目的、関連するIssue番号など -->

IP制限（拒否リスト）とログイン履歴とE2Eテストを追加しました

refs https://github.com/EC-CUBE/ec-cube/pull/4978

## 方針(Policy)

最低限ですがテストを追加しています。

## テスト（Test)

GitHub Actions で通ることを確認。
別要因で2個落ちています。

## マイナーバージョン互換性保持のための制限事項チェックリスト
<!-- マイナーバージョンでは、機能・プラグイン・デザインテンプレート互換性を損なう変更は原則取り込みません。 -->

- [x] 既存機能の仕様変更
- [x] フックポイントの呼び出しタイミングの変更
- [x] フックポイントのパラメータの削除・データ型の変更
- [x] twigファイルに渡しているパラメータの削除・データ型の変更
- [x] Serviceクラスの公開関数の、引数の削除・データ型の変更
- [x] 入出力ファイル(CSVなど)のフォーマット変更

## レビュワー確認項目

- [ ] 動作確認
- [ ] コードレビュー
- [ ] E2E/Unit テスト確認(テストの追加・変更が必要かどうか)
- [ ] 互換性が保持されているか
- [ ] セキュリティ上の問題がないか
