### PR TITLE
プロキシファイルパス生成時にサブディレクトリ構造を保持するよう修正

### DIFF
--- a/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
+++ b/src/Eccube/Doctrine/ORM/Mapping/Driver/AnnotationDriver.php
@@ -77,7 +77,7 @@ class AnnotationDriver extends \Doctrine\ORM\Mapping\Driver\AnnotationDriver
                     $projectDir = str_replace('\\', '/', $projectDir);
                 }
                 // Replace /path/to/ec-cube to proxies path
-                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, $path).'/'.basename($sourceFile);
+                $proxyFile = str_replace($projectDir, $this->trait_proxies_directory, dirname($sourceFile)).'/'.basename($sourceFile);
                 if (file_exists($proxyFile)) {
                     require_once $proxyFile;
 


### PR DESCRIPTION
修正前の問題:
- $path（検索ルートディレクトリ）を使用していた
- サブディレクトリ構造が失われ、正しいパスが生成されなかった
- ネストされたエンティティのプロキシファイルが見つからなかった

修正内容:
- dirname($sourceFile)（ファイルの実際のディレクトリ）を使用
- サブディレクトリ（例: Master/）を含む完全なパス構造を保持
- すべてのエンティティで正しいプロキシファイルパスを生成"